### PR TITLE
Exponential Backoff Dynamic Refresh

### DIFF
--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -751,7 +751,7 @@ WAIT_STABLE:
         best_avg, best_size, tFC_hit_, best_option_tMiss);
     }
   }
-
+  
   // Compare best "partially" frozen [0, 100%) one with 100% Frozen
   if(best_avg > Frozen_Avg){
     printf("(Update) best avg: %.3lf us, best size: %.3lf\n",

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -954,7 +954,7 @@ CONSTRUCT:
     exponent_cap = 0;
     exponential_backoff_remaining = 0;
   } else {
-    exponent_cap == 0 ? 1 : exponent_cap * 2;
+    exponent_cap = exponent_cap == 0 ? 1 : exponent_cap * 2;
     exponential_backoff_remaining = exponent_cap;
   }
   previous_baseline_performance_with_threshold = baseline_performance_with_threshold

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -751,7 +751,7 @@ WAIT_STABLE:
         best_avg, best_size, tFC_hit_, best_option_tMiss);
     }
   }
-  
+
   // Compare best "partially" frozen [0, 100%) one with 100% Frozen
   if(best_avg > Frozen_Avg){
     printf("(Update) best avg: %.3lf us, best size: %.3lf\n",
@@ -970,7 +970,7 @@ FROZEN_RUN:
   bool first_flag = true;
   size_t total_step = 0;
   size_t current_step = 0;
-
+  
   while(!should_stop) {
     do{
       usleep(check_time);

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -758,14 +758,10 @@ WAIT_STABLE:
   }
 
   if(best_option_tMiss < previousMissRatio){
-    exponent = 0;
+    exponentCap = 0;
     exponentialBackoffRemaining = 0;
   } else {
-    if(exponentCap == 0){
-      exponentCap = 1;
-    } else {
-      exponentCap *= 2;
-    }
+    exponentCap == 0 ? 1 : exponentCap * 2;
     exponentialBackoffRemaining = exponentCap;
   }
   previousMissRatio = best_option_tMiss


### PR DESCRIPTION
## FIFO_FH New Implementation
```
All threads run 94.499428 s
- Hit Avg: 0.166 (stat size: 210918, real size_: 210918), median: 0.090, p9999: 14.590, p999: 1.182, p99: 0.681, p90: 0.380
- Other Avg: 7.054 (stat size: 9108, real size_: 9108), median: 5.258, p9999: 11183.913, p999: 87.169, p99: 6.759, p90: 6.078
Total Avg Lat: 0.451 (size: 220026, miss ratio: 0.041395)
```

## FIFO_FH Original
```
All threads run 82.996116 s
- Hit Avg: 0.124 (stat size: 216787, real size_: 216787), median: 0.080, p9999: 4.316, p999: 1.070, p99: 0.549, p90: 0.180
- Other Avg: 5.554 (stat size: 9146, real size_: 9146), median: 5.237, p9999: 372.539, p999: 74.613, p99: 6.328, p90: 5.737
Total Avg Lat: 0.343 (size: 225933, miss ratio: 0.040481)
```

## LRU_FH New Implementation
```
All threads run 67.280254 s
- Hit Avg: 0.117 (stat size: 224443, real size_: 224443), median: 0.061, p9999: 12.297, p999: 1.202, p99: 0.720, p90: 0.171
- Other Avg: 5.713 (stat size: 5917, real size_: 5917), median: 5.228, p9999: 250.742, p999: 100.196, p99: 6.580, p90: 5.788
Total Avg Lat: 0.260 (size: 230360, miss ratio: 0.025686)
```

## LRU_FH Original
```
All threads run 68.348108 s
- Hit Avg: 0.131 (stat size: 222657, real size_: 222657), median: 0.080, p9999: 6.618, p999: 1.042, p99: 0.691, p90: 0.181
- Other Avg: 5.844 (stat size: 5964, real size_: 5964), median: 5.237, p9999: 745.738, p999: 102.330, p99: 6.459, p90: 5.778
Total Avg Lat: 0.280 (size: 228621, miss ratio: 0.026087)
```