### PR TITLE
Added chunk segmentation logic during construction

### DIFF
--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -303,7 +303,7 @@ FIFO_FHCache<TKey, TValue, THash>::FIFO_FHCache(size_t maxSize, double chunkRati
 template <class TKey, class TValue, class THash>
 bool FIFO_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
   // Check valid ratio
-  assert(FC_ratio <= 1 && FC_ratio >=0);
+  assert(FC_ratio <= 1 && FC_ratio > 0);
   
   std::unique_lock<ListMutex> upperLock(m_listMutex);
   // Check that Frozen LinkedList is empty (previously in DC mode)


### PR DESCRIPTION
* Added logic to segment node chunks directly during FC construction
  * Ideally more efficient, so only done in one pass

```
All threads run 119.027986 s
- Hit Avg: 0.289 (stat size: 219799, real size_: 219799), median: 0.200, p9999: 41.400, p999: 2.200, p99: 1.000, p90: 0.500
- Other Avg: 6.009 (stat size: 8931, real size_: 8931), median: 5.400, p9999: 402.400, p999: 65.400, p99: 9.400, p90: 6.600
Total Avg Lat: 0.512 (size: 228730, miss ratio: 0.039046)
```

```
All threads run 165.367535 s
- Hit Avg: 0.507 (stat size: 219001, real size_: 219001), median: 0.300, p9999: 74.700, p999: 4.300, p99: 1.500, p90: 0.800
- Other Avg: 6.666 (stat size: 9320, real size_: 9320), median: 6.200, p9999: 384.800, p999: 60.900, p99: 12.100, p90: 7.800
Total Avg Lat: 0.758 (size: 228321, miss ratio: 0.040820)
```

