### PR TITLE
Global counter technique for checking if key is in frozen list

### DIFF
--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -465,10 +465,10 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_tier() {
   ListNode* delete_temp;
   HashMapConstAccessor temp_hashAccessor;
 
-  // int chunkSize = std::ceil(m_size.load() * CHUNK_RATIO);
-  // int chunkCounter = 0;
-  // chunkMapper.clear();
-  // chunks.clear();
+  int chunkSize = std::ceil(m_size.load() * CHUNK_RATIO);
+  int chunkCounter = 0;
+  chunkMapper.clear();
+  chunks.clear();
   
   while(temp_node != &m_fast_tail){
 #ifdef HANDLE_WRITE
@@ -510,21 +510,20 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_tier() {
     }
 #endif
    
-   /*
-  if (count % chunkSize == 0) {
-      chunkCounter += 1;
-      std::unique_lock<ListMutex> lock(m_listMutex);
-      chunks.push_back(temp_node);
-      lock.unlock();
-    }
-  chunkMapper[temp_node->m_key] = chunkCounter;
-    */
+   
+    if (count % chunkSize == 0) {
+        chunkCounter += 1;
+        std::unique_lock<ListMutex> lock(m_listMutex);
+        chunks.push_back(temp_node);
+      }
+    chunkMapper[temp_node->m_key] = chunkCounter;
+  
     // Insert the valid node to Frozen
     m_fasthash->insert(temp_node->m_key, temp_hashAccessor->second.m_value);
     count++;
     temp_node = temp_node->m_next;
   }
-  // chunkGlobalCounter = chunkCounter + 1;
+  chunkGlobalCounter = chunkCounter + 1;
   printf("fast hash insert num: %d, m_size: %ld (FC_ratio: %.2lf)\n", 
       count, m_size.load(), count*1.0/m_size.load());
   tier_ready = true;

--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -630,7 +630,7 @@ bool FIFO_FHCache<TKey, TValue, THash>::find(TValue& ac,
     // Generally when we found the thing in frozen cache
     if((chunkMapper.find(key) != chunkMapper.end()) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac) && (ac != nullptr))
 #else
-    if(chunkMapper.find(key) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac))
+    if((chunkMapper.find(key) != chunkMapper.end()) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac))
 #endif
     {
 #ifdef FH_STAT

--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -652,7 +652,7 @@ bool FIFO_FHCache<TKey, TValue, THash>::find(TValue& ac,
   }
 
   // Now we try to find in DC if data not in FC
-  if (!m_map.find(hashAccessor, key)) {
+  if (!m_map.find(hashAccessor, key) || hashAccessor->second.m_listNode->m_key == TOMB_KEY) {
 #ifdef FH_STAT
     if(stat_yes) {
       FIFO_FHCache::tbb_find_miss++;
@@ -661,7 +661,6 @@ bool FIFO_FHCache<TKey, TValue, THash>::find(TValue& ac,
     // Not found in DC also (cache miss)
     return false;
   }
-  
   // Now we found it in DC
   ac = hashAccessor->second.m_value;
   

--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -467,10 +467,15 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_tier() {
 
   int chunkSize = std::ceil(m_size.load() * CHUNK_RATIO);
   int chunkCounter = 0;
+  bool insertNextNodeInChunk = false;
   chunkMapper.clear();
   chunks.clear();
   
   while(temp_node != &m_fast_tail){
+    if (count % chunkSize == 0) {
+      insertNextNodeInChunk = true;
+      chunkCounter += 1;
+    }
 #ifdef HANDLE_WRITE
     /*
      * If the node key is tomb, clean tomb node; 
@@ -509,17 +514,17 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_tier() {
       continue;
     }
 #endif
-   
-   
-    if (count % chunkSize == 0) {
-        chunkCounter += 1;
-        std::unique_lock<ListMutex> lock(m_listMutex);
-        chunks.push_back(temp_node);
-      }
-    chunkMapper[temp_node->m_key] = chunkCounter;
-  
+
     // Insert the valid node to Frozen
     m_fasthash->insert(temp_node->m_key, temp_hashAccessor->second.m_value);
+    chunkMapper[temp_node->m_key] = chunkCounter;
+    if (insertNextNodeInChunk) {
+      std::unique_lock<ListMutex> lock(m_listMutex);
+      chunks.push_back(temp_node);
+      lock.unlock();
+      insertNextNodeInChunk = false;
+    }
+    
     count++;
     temp_node = temp_node->m_next;
   }
@@ -963,25 +968,24 @@ inline void FIFO_FHCache<TKey, TValue, THash>::pushAfter(ListNode* nodeBefore, L
 
 template <class TKey, class TValue, class THash>
 inline void FIFO_FHCache<TKey, TValue, THash>::melt_chunk() {
-  if(fast_hash_ready) {
-    std::unique_lock<ListMutex> lock(m_listMutex);
-    if (chunks.size() == 0) return;
-    ListNode* chunkNodeHead = chunks.back();
-    chunks.pop_back();
-    if(m_fast_tail.m_prev == &m_fast_head) return;
-    ListNode* lastNode = m_fast_tail.m_prev;
-    ListNode* nextNode = m_head.m_next;
+  if(!fast_hash_ready) return;
+  std::unique_lock<ListMutex> lock(m_listMutex);
+  if (chunks.size() == 0) return;
+  ListNode* chunkNodeHead = chunks.back();
+  chunks.pop_back();
+  if(m_fast_tail.m_prev == &m_fast_head) return;
+  ListNode* lastNode = m_fast_tail.m_prev;
+  ListNode* nextNode = m_head.m_next;
 
-    chunkNodeHead->m_prev->m_next = &m_fast_tail;
-    m_fast_tail.m_prev = chunkNodeHead->m_prev;
+  chunkNodeHead->m_prev->m_next = &m_fast_tail;
+  m_fast_tail.m_prev = chunkNodeHead->m_prev;
 
-    m_head.m_next = chunkNodeHead;
-    chunkNodeHead->m_prev = &m_head;
-    lastNode->m_next = nextNode;
-    nextNode->m_prev = lastNode;
-    lock.unlock();
-    chunkGlobalCounter -= 1;
-  }
+  m_head.m_next = chunkNodeHead;
+  chunkNodeHead->m_prev = &m_head;
+  lastNode->m_next = nextNode;
+  nextNode->m_prev = lastNode;
+  lock.unlock();
+  chunkGlobalCounter -= 1;
 }
 
 // Eviction logic

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -204,7 +204,7 @@ private:
   std::queue<int> construct_container; // Note that this is a queue not a stack
   int PASS_THRESHOLD = 3;
 
-  int MELT_CHUNK_FRACTION = 0.2;
+  float MELT_CHUNK_FRACTION = 0.2;
   int COUNT_THRESHOLD = 2;
   double performance_depletion = COUNT_THRESHOLD;
   double best_sleep = 0;

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -204,7 +204,7 @@ private:
   std::queue<int> construct_container; // Note that this is a queue not a stack
   int PASS_THRESHOLD = 3;
 
-  float MELT_CHUNK_FRACTION = 0.2;
+  float CHUNK_RATIO = 0.2;
   int COUNT_THRESHOLD = 2;
   double performance_depletion = COUNT_THRESHOLD;
   double best_sleep = 0;
@@ -272,7 +272,7 @@ ConcurrentScalableCache(size_t maxSize, size_t numShards, Type type, int rebuild
     }
     else if(algType == Type::FIFO_FH) {
       assert(FROZEN_THRESHOLD > 0);
-      m_shards.emplace_back(std::make_shared<Cache::FIFO_FHCache<TKey, TValue, THash>>(s, MELT_CHUNK_FRACTION));
+      m_shards.emplace_back(std::make_shared<Cache::FIFO_FHCache<TKey, TValue, THash>>(s, CHUNK_RATIO));
     }
     else {
       printf("cannot find the cache type\n");
@@ -1037,11 +1037,11 @@ CONSTRUCT:
 
     /**
      * Trigger to melt next chunk if performance depletion fraction meets next threshold
-     * Ex: First chunk melts if performance degrades by more than MELT_CHUNK_FRACTION (20%) from COUNT_THRESHOLD (starting buffer)
+     * Ex: First chunk melts if performance degrades by more than CHUNK_RATIO (20%) from COUNT_THRESHOLD (starting buffer)
      * Importantly last chunk never melted, since if performance_depletion < 0, then deconstruction occurs earlier
     */
     double performance_depletion_fraction = 1 - (performance_depletion*1.0 / COUNT_THRESHOLD);
-    double performance_depletion_threshold = (melted_chunks_count + 1) * MELT_CHUNK_FRACTION;
+    double performance_depletion_threshold = (melted_chunks_count + 1) * CHUNK_RATIO;
     if (performance_depletion_fraction > performance_depletion_threshold) {
       melted_chunks_count++;
       for(size_t i = 0; i < m_numShards; i++) {


### PR DESCRIPTION
Overall bench mark result with global counter:
All threads run 141.045948 s
- Hit Avg: 0.348 (stat size: 220599, real size_: 220599), median: 0.300, p9999: 28.400, p999: 2.600, p99: 1.000, p90: 0.600
- Other Avg: 6.383 (stat size: 9374, real size_: 9374), median: 6.000, p9999: 480.100, p999: 46.000, p99: 17.400, p90: 6.800
Total Avg Lat: 0.594 (size: 229973, miss ratio: 0.040761)