### PR TITLE
Added melting logic to LRU and LFU

### DIFF
--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -255,7 +255,7 @@ ConcurrentScalableCache(size_t maxSize, size_t numShards, Type type, int rebuild
       m_shards.emplace_back(std::make_shared<Cache::LFUCache<TKey, TValue, THash>>(s));
     else if(algType == Type::LRU_FH) {
       assert(FROZEN_THRESHOLD > 0);
-      m_shards.emplace_back(std::make_shared<Cache::LRU_FHCache<TKey, TValue, THash>>(s));
+      m_shards.emplace_back(std::make_shared<Cache::LRU_FHCache<TKey, TValue, THash>>(s, CHUNK_RATIO));
     }
     else if(algType == Type::Redis_LRU) {
       m_shards.emplace_back(std::make_shared<Cache::RedisLRUCache<TKey, TValue, THash>>(s));
@@ -268,7 +268,7 @@ ConcurrentScalableCache(size_t maxSize, size_t numShards, Type type, int rebuild
     }
     else if(algType == Type::LFU_FH) {
       assert(FROZEN_THRESHOLD > 0);
-      m_shards.emplace_back(std::make_shared<Cache::LFU_FHCache<TKey, TValue, THash>>(s));
+      m_shards.emplace_back(std::make_shared<Cache::LFU_FHCache<TKey, TValue, THash>>(s, CHUNK_RATIO));
     }
     else if(algType == Type::FIFO_FH) {
       assert(FROZEN_THRESHOLD > 0);


### PR DESCRIPTION
LFU
- Linked list of freq bucket nodes that hold a linked list of actual key nodes
- Use a counter to keep track of how many chunk nodes we're behind because we can only segment at the bucket level
- No mention of TOMB_KEY (not sure how they get around it)

Minor changes to general logic
- Removed `insertNextNodeInChunk` for construct_tier functions in FIFO and LRU
- Fixed melting_chunk to not exit in case logic comes from `construct_tier` instead of `construct_ratio`

