### PR TITLE
linear time, low overhead melt implementation for FH_FIFO

### DIFF
--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -28,7 +28,6 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <unordered_map>
 
 // stat
 #define FH_STAT
@@ -224,7 +223,6 @@ class FIFO_FHCache : public FHCacheAPI<TKey, TValue, THash> {
    */
   void melt_chunk();
 
-
   /**
    * Evict the least-recently used item from the container. This function does
    * its own locking.
@@ -242,6 +240,11 @@ class FIFO_FHCache : public FHCacheAPI<TKey, TValue, THash> {
    * number of elements in the container.
    */
   std::atomic<size_t> m_size;
+
+  /**
+   * The size of the frozen cache, recalculated on every construct_ratio call
+  */  
+  size_t FC_size;
 
   /**
    * The underlying TBB hash map.
@@ -273,11 +276,7 @@ class FIFO_FHCache : public FHCacheAPI<TKey, TValue, THash> {
   ListNode m_fast_tail;
   ListNode *m_marker = nullptr;
 
-  std::vector<ListNode*> chunks;
   const double CHUNK_RATIO;
-
-  std::unordered_map<TKey, int> chunkMapper;
-  std::atomic<int> chunkGlobalCounter; 
 };
 
 template <class TKey, class TValue, class THash>
@@ -326,7 +325,7 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
   fast_hash_construct = true;
   
   // Compute split sizes
-  size_t FC_size = FC_ratio * m_maxSize;
+  FC_size = FC_ratio * m_maxSize;
   size_t DC_size = m_maxSize - FC_size;
   printf("FC_size: %lu, DC_size: %lu\n", FC_size, DC_size);
   size_t fail_count = 0, count = 0;
@@ -338,20 +337,7 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
   ListNode* delete_temp;
   HashMapConstAccessor temp_hashAccessor;
 
-  // Chunk management logic
-  assert(CHUNK_RATIO > 0);
-  int chunkSize = std::ceil(FC_size*CHUNK_RATIO);
-  bool insertNextNodeInChunk = false;
-  int chunkCounter = 0;
-  chunks.clear();
-  chunkMapper.clear();
-
   while(temp_node != &m_fast_tail) {
-    if (count % chunkSize == 0) {
-      insertNextNodeInChunk = true;
-      chunkCounter += 1;
-    }
-
     count++;
     auto eviction_count = eviction_counter.load();
     
@@ -374,13 +360,6 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
     
     // Node exists
     m_fasthash->insert(temp_node->m_key, temp_hashAccessor->second.m_value);
-    chunkMapper[temp_node->m_key] = chunkCounter;
-    if (insertNextNodeInChunk) {
-      std::unique_lock<ListMutex> lock(m_listMutex);
-      chunks.push_back(temp_node);
-      lock.unlock();
-      insertNextNodeInChunk = false;
-    }
     temp_node = temp_node->m_next;
 
     // cutoff FC list, in two cases
@@ -418,7 +397,7 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
       first_pass_flag = false;
     }
   }
-  chunkGlobalCounter = chunkCounter + 1;
+  
   
   if(fail_count > 0)
     printf("fast hash insert num: %lu, fail count: %lu, m_size: %ld (FC_ratio: %.2lf)\n", 
@@ -464,11 +443,6 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_tier() {
   ListNode* delete_temp;
   HashMapConstAccessor temp_hashAccessor;
 
-  int chunkSize = std::ceil(m_size.load() * CHUNK_RATIO);
-  int chunkCounter = 0;
-  chunkMapper.clear();
-  chunks.clear();
-  
   while(temp_node != &m_fast_tail){
 #ifdef HANDLE_WRITE
     /*
@@ -510,17 +484,9 @@ bool FIFO_FHCache<TKey, TValue, THash>::construct_tier() {
 #endif
     // Insert the valid node to Frozen
     m_fasthash->insert(temp_node->m_key, temp_hashAccessor->second.m_value);
-    chunkMapper[temp_node->m_key] = chunkCounter;
-    if (count % chunkSize == 0) {
-      chunkCounter += 1;
-      std::unique_lock<ListMutex> lock(m_listMutex);
-      chunks.push_back(temp_node);
-      lock.unlock();
-    }
     count++;
     temp_node = temp_node->m_next;
   }
-  chunkGlobalCounter = chunkCounter + 1;
   printf("fast hash insert num: %d, m_size: %ld (FC_ratio: %.2lf)\n", 
       count, m_size.load(), count*1.0/m_size.load());
   tier_ready = true;
@@ -624,9 +590,9 @@ bool FIFO_FHCache<TKey, TValue, THash>::find(TValue& ac,
     // we can re-check this and remove it if possible
 
     // Generally when we found the thing in frozen cache
-    if((chunkMapper.find(key) != chunkMapper.end()) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac) && (ac != nullptr))
+    if(m_fasthash->find(key, ac) && (ac != nullptr))
 #else
-    if((chunkMapper.find(key) != chunkMapper.end()) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac))
+    if(m_fasthash->find(key, ac))
 #endif
     {
 #ifdef FH_STAT
@@ -649,7 +615,7 @@ bool FIFO_FHCache<TKey, TValue, THash>::find(TValue& ac,
   }
 
   // Now we try to find in DC if data not in FC
-  if (!m_map.find(hashAccessor, key) || hashAccessor->second.m_listNode->m_key == TOMB_KEY) {
+  if (!m_map.find(hashAccessor, key)) {
 #ifdef FH_STAT
     if(stat_yes) {
       FIFO_FHCache::tbb_find_miss++;
@@ -960,23 +926,25 @@ inline void FIFO_FHCache<TKey, TValue, THash>::pushAfter(ListNode* nodeBefore, L
 template <class TKey, class TValue, class THash>
 inline void FIFO_FHCache<TKey, TValue, THash>::melt_chunk() {
   if(!(fast_hash_ready || tier_ready) || fast_hash_construct) return;
+  if(m_fast_tail == nullptr || m_fast_tail.m_prev == &m_fast_head) return;
+  assert(CHUNK_RATIO > 0);
+  int chunkSize = std::ceil(FC_size*CHUNK_RATIO);
+
   std::unique_lock<ListMutex> lock(m_listMutex);
-  if (chunks.size() == 0) return;
-  ListNode* chunkNodeHead = chunks.back();
-  chunks.pop_back();
-  if(m_fast_tail.m_prev == &m_fast_head) return;
-  ListNode* lastNode = m_fast_tail.m_prev;
-  ListNode* nextNode = m_head.m_next;
-
-  chunkNodeHead->m_prev->m_next = &m_fast_tail;
-  m_fast_tail.m_prev = chunkNodeHead->m_prev;
-
-  m_head.m_next = chunkNodeHead;
-  chunkNodeHead->m_prev = &m_head;
-  lastNode->m_next = nextNode;
-  nextNode->m_prev = lastNode;
-  lock.unlock();
-  chunkGlobalCounter -= 1;
+  ListNode* node_to_move = m_fast_tail.m_prev;
+  for (int i = 0; node_to_move != &m_fast_head && i < chunkSize; i++) {
+    ListNode* next_node_to_move = node_to_move->m_prev;
+    if(node_to_move->m_key == TOMB_KEY) {
+      delink(node_to_move);
+      delete node_to_move;
+    } else {
+      node_to_move->m_prev->m_next = &m_fast_tail;
+      m_fast_tail.m_prev = node_to_move->m_prev;
+      pushFront(node_to_move);
+      m_fasthash->erase(node_to_move->m_key);
+    }
+    node_to_move = next_node_to_move;
+  }
 }
 
 // Eviction logic

--- a/cache/FIFO_FH.h
+++ b/cache/FIFO_FH.h
@@ -926,7 +926,7 @@ inline void FIFO_FHCache<TKey, TValue, THash>::pushAfter(ListNode* nodeBefore, L
 template <class TKey, class TValue, class THash>
 inline void FIFO_FHCache<TKey, TValue, THash>::melt_chunk() {
   if(!(fast_hash_ready || tier_ready) || fast_hash_construct) return;
-  if(m_fast_tail == nullptr || m_fast_tail.m_prev == &m_fast_head) return;
+  if(m_fast_tail.m_prev == &m_fast_head) return;
   assert(CHUNK_RATIO > 0);
   int chunkSize = std::ceil(FC_size*CHUNK_RATIO);
 
@@ -941,7 +941,7 @@ inline void FIFO_FHCache<TKey, TValue, THash>::melt_chunk() {
       node_to_move->m_prev->m_next = &m_fast_tail;
       m_fast_tail.m_prev = node_to_move->m_prev;
       pushFront(node_to_move);
-      m_fasthash->erase(node_to_move->m_key);
+      m_fasthash->remove_key(node_to_move->m_key);
     }
     node_to_move = next_node_to_move;
   }

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -268,7 +268,7 @@ ConcurrentScalableCache(size_t maxSize, size_t numShards, Type type, int rebuild
     }
     else if(algType == Type::LFU_FH) {
       assert(FROZEN_THRESHOLD > 0);
-      m_shards.emplace_back(std::make_shared<Cache::LFU_FHCache<TKey, TValue, THash>>(s, CHUNK_RATIO));
+      m_shards.emplace_back(std::make_shared<Cache::LFU_FHCache<TKey, TValue, THash>>(s));
     }
     else if(algType == Type::FIFO_FH) {
       assert(FROZEN_THRESHOLD > 0);

--- a/cache/hhvm-scalable-cache.h
+++ b/cache/hhvm-scalable-cache.h
@@ -204,7 +204,7 @@ private:
   std::queue<int> construct_container; // Note that this is a queue not a stack
   int PASS_THRESHOLD = 3;
 
-  float CHUNK_RATIO = 0.2;
+  float CHUNK_RATIO = 1.0/3.0;
   int COUNT_THRESHOLD = 2;
   double performance_depletion = COUNT_THRESHOLD;
   double best_sleep = 0;

--- a/cache/hhvm_lru_cache_FH.h
+++ b/cache/hhvm_lru_cache_FH.h
@@ -694,7 +694,7 @@ bool LRU_FHCache<TKey, TValue, THash>::get_curve(bool& should_stop) {
 template <class TKey, class TValue, class THash>
  void  LRU_FHCache<TKey, TValue, THash>::melt_chunk() {
   if(!(fast_hash_ready || tier_ready) || fast_hash_construct) return;
-  if(m_fast_tail == nullptr || m_fast_tail.m_prev == &m_fast_head) return;
+  if(m_fast_tail.m_prev == &m_fast_head) return;
   assert(CHUNK_RATIO > 0);
   int chunkSize = std::ceil(FC_size*CHUNK_RATIO);
 
@@ -709,7 +709,7 @@ template <class TKey, class TValue, class THash>
       node_to_move->m_prev->m_next = &m_fast_tail;
       m_fast_tail.m_prev = node_to_move->m_prev;
       pushFront(node_to_move);
-      m_fasthash->erase(node_to_move->m_key);
+      m_fasthash->remove_key(node_to_move->m_key);
     }
     node_to_move = next_node_to_move;
   }

--- a/cache/hhvm_lru_cache_FH.h
+++ b/cache/hhvm_lru_cache_FH.h
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include <unordered_map>
+
 // stat
 #define FH_STAT
 #define HANDLE_WRITE
@@ -246,6 +246,11 @@ class LRU_FHCache : public FHCacheAPI<TKey, TValue, THash> {
   std::atomic<size_t> m_size;
 
   /**
+   * The size of the frozen cache, recalculated on every construct_ratio call
+  */  
+  size_t FC_size;
+
+  /**
    * The underlying TBB hash map.
    */
   HashMap m_map;
@@ -277,11 +282,7 @@ class LRU_FHCache : public FHCacheAPI<TKey, TValue, THash> {
   ListNode m_fast_tail;
   ListNode *m_marker = nullptr;
 
-  std::vector<ListNode*> chunks;
   const double CHUNK_RATIO;
-
-  std::unordered_map<TKey, int> chunkMapper;
-  std::atomic<int> chunkGlobalCounter; 
 };
 
 template <class TKey, class TValue, class THash>
@@ -331,7 +332,7 @@ bool LRU_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
   // for thread safety
   fast_hash_construct = true;
 
-  size_t FC_size = FC_ratio * m_maxSize;
+  FC_size = FC_ratio * m_maxSize;
   size_t DC_size = m_maxSize - FC_size;
   printf("FC_size: %lu, DC_size: %lu\n", FC_size, DC_size);
   size_t fail_count = 0, count = 0;
@@ -345,20 +346,7 @@ bool LRU_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
   ListNode* delete_temp;
   HashMapConstAccessor temp_hashAccessor;
 
-  // Chunk management logic
-  assert(CHUNK_RATIO > 0);
-  int chunkSize = std::ceil(FC_size * CHUNK_RATIO);
-  bool insertNextNodeInChunk = false;
-  int chunkCounter = 0;
-  chunks.clear();
-  chunkMapper.clear();
-
   while(temp_node != &m_fast_tail){
-    if (count % chunkSize == 0) {
-      insertNextNodeInChunk = true;
-      chunkCounter += 1;
-    }
-
     count++;
     auto eviction_count = eviction_counter.load();
     if(!m_map.find(temp_hashAccessor, temp_node->m_key)){
@@ -375,13 +363,6 @@ bool LRU_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
 
     // Node exists
     m_fasthash->insert(temp_node->m_key, temp_hashAccessor->second.m_value);
-    chunkMapper[temp_node->m_key] = chunkCounter;
-    if (insertNextNodeInChunk) {
-      std::unique_lock<ListMutex> lock(m_listMutex);
-      chunks.push_back(temp_node);
-      lock.unlock();
-      insertNextNodeInChunk = false;
-    }
     temp_node = temp_node->m_next;
 
     // TODO @ Ziyue: eliminate FC_RELAXATION
@@ -413,7 +394,6 @@ bool LRU_FHCache<TKey, TValue, THash>::construct_ratio(double FC_ratio) {
       first_pass_flag = false;
     }
   }
-  chunkGlobalCounter = chunkCounter + 1;
   
   if(fail_count > 0)
     printf("fast hash insert num: %lu, fail count: %lu, m_size: %ld (FC_ratio: %.2lf)\n", 
@@ -448,11 +428,6 @@ bool LRU_FHCache<TKey, TValue, THash>::construct_tier() {
   ListNode* delete_temp;
   HashMapConstAccessor temp_hashAccessor;
 
-  int chunkSize = std::ceil(m_size.load() * CHUNK_RATIO);
-  int chunkCounter = 0;
-  chunkMapper.clear();
-  chunks.clear();
-
   while(temp_node != &m_fast_tail){
 #ifdef HANDLE_WRITE
     if(temp_node->m_key == TOMB_KEY) {
@@ -482,17 +457,9 @@ bool LRU_FHCache<TKey, TValue, THash>::construct_tier() {
     }
 #endif
     m_fasthash->insert(temp_node->m_key, temp_hashAccessor->second.m_value);
-    chunkMapper[temp_node->m_key] = chunkCounter;
-    if (count % chunkSize == 0) {
-      chunkCounter += 1;
-      std::unique_lock<ListMutex> lock(m_listMutex);
-      chunks.push_back(temp_node);
-      lock.unlock();
-    }
     count++;
     temp_node = temp_node->m_next;
   }
-  chunkGlobalCounter = chunkCounter + 1;
   printf("fast hash insert num: %d, m_size: %ld (FC_ratio: %.2lf)\n", 
       count, m_size.load(), count*1.0/m_size.load());
   tier_ready = true;
@@ -576,9 +543,9 @@ bool LRU_FHCache<TKey, TValue, THash>::find(TValue& ac,
 
   if(tier_ready || fast_hash_ready) {
 #ifdef HANDLE_WRITE
-    if((chunkMapper.find(key) != chunkMapper.end()) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac) && (ac != nullptr))
+    if(m_fasthash->find(key, ac) && (ac != nullptr))
 #else
-    if((chunkMapper.find(key) != chunkMapper.end()) && (chunkMapper[key] < chunkGlobalCounter) && m_fasthash->find(key, ac))
+    if(m_fasthash->find(key, ac))
 #endif
     {
 
@@ -602,7 +569,7 @@ bool LRU_FHCache<TKey, TValue, THash>::find(TValue& ac,
   }
 
   // Now we try to find in DC if data not in FC
-  if (!m_map.find(hashAccessor, key) || hashAccessor->second.m_listNode->m_key == TOMB_KEY) {
+  if (!m_map.find(hashAccessor, key)) {
 #ifdef FH_STAT
     if(stat_yes) {
       LRU_FHCache::tbb_find_miss++;
@@ -727,24 +694,26 @@ bool LRU_FHCache<TKey, TValue, THash>::get_curve(bool& should_stop) {
 template <class TKey, class TValue, class THash>
  void  LRU_FHCache<TKey, TValue, THash>::melt_chunk() {
   if(!(fast_hash_ready || tier_ready) || fast_hash_construct) return;
+  if(m_fast_tail == nullptr || m_fast_tail.m_prev == &m_fast_head) return;
+  assert(CHUNK_RATIO > 0);
+  int chunkSize = std::ceil(FC_size*CHUNK_RATIO);
+
   std::unique_lock<ListMutex> lock(m_listMutex);
-  if (chunks.size() == 0) return;
-  ListNode* chunkNodeHead = chunks.back();
-  chunks.pop_back();
-  if(m_fast_tail.m_prev == &m_fast_head) return;
-  ListNode* lastNode = m_fast_tail.m_prev;
-  ListNode* nextNode = m_head.m_next;
-
-  chunkNodeHead->m_prev->m_next = &m_fast_tail;
-  m_fast_tail.m_prev = chunkNodeHead->m_prev;
-
-  m_head.m_next = chunkNodeHead;
-  chunkNodeHead->m_prev = &m_head;
-  lastNode->m_next = nextNode;
-  nextNode->m_prev = lastNode;
-  lock.unlock();
-  chunkGlobalCounter -= 1;
- }
+  ListNode* node_to_move = m_fast_tail.m_prev;
+  for (int i = 0; node_to_move != &m_fast_head && i < chunkSize; i++) {
+    ListNode* next_node_to_move = node_to_move->m_prev;
+    if(node_to_move->m_key == TOMB_KEY) {
+      delink(node_to_move);
+      delete node_to_move;
+    } else {
+      node_to_move->m_prev->m_next = &m_fast_tail;
+      m_fast_tail.m_prev = node_to_move->m_prev;
+      pushFront(node_to_move);
+      m_fasthash->erase(node_to_move->m_key);
+    }
+    node_to_move = next_node_to_move;
+  }
+}
 
 template <class TKey, class TValue, class THash>
 bool LRU_FHCache<TKey, TValue, THash>::insert(const TKey& key,


### PR DESCRIPTION
- Implementation of chunk transfer and hash removal via iterating through each node directly on melt for all algos
  - LFU importantly doesn't both using CHUNK_RATIO to iterate through and count nodes, simply melts last frequency bucket of nodes